### PR TITLE
Adding gencode parameter to RSEM workflow, support for more assemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.2] - 2026-04-25
+## [1.1.3] - 2026-04-25
 ### Added
-- additional genomic resources, hg38_noAlt and grch38
+- additional genomic resources, hg38_noAlt and grch38, gencode parameter
 ### Changed
 - nested structure of genomic resources, additional layer to handle different gencode versions
+
+## [1.1.2] - 2025-12-05
+### Added
+- noAlt and ncbi references added
 
 ## [1.1.1] - 2025-09-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2026-04-25
+### Added
+- additional genomic resources, hg38_noAlt and grch38
+### Changed
+- nested structure of genomic resources, additional layer to handle different gencode versions
+
 ## [1.1.1] - 2025-09-25
 ### Changed
 - [GRD-964](https://jira.oicr.on.ca/browse/GRD-964)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Parameter|Value|Description
 `inputBam`|File|Input BAM file with aligned RNAseq reads.
 `outputFileNamePrefix`|String|Output prefix, customizable. Default is the input file's basename.
 `reference`|String|Name and version of reference genome
+`gencode`|String|Version of gencode used to generate the RSEM indexes
 
 
 #### Optional workflow parameters:

--- a/rsem.wdl
+++ b/rsem.wdl
@@ -11,26 +11,54 @@ input {
   File inputBam
   String outputFileNamePrefix
   String reference
+  String gencode
 }
 
-Map[String, GenomeResources] resources = {
+Map[String, Map[String, GenomeResources]] resources = {
   "hg19": {
-    "reference_modules": "rsem/1.3.3 hg19-rsem-index/1.3.3",
-    "reference_indexdir": "$HG19_RSEM_INDEX_ROOT/hg19_random_rsem"
+    "31": { 
+      "reference_modules": "rsem/1.3.3 hg19-rsem-index/1.3.3",
+      "reference_indexdir": "$HG19_RSEM_INDEX_ROOT/hg19_random_rsem"
+    }
   },
   "hg38": {
-    "reference_modules": "rsem/1.3.3 hg38-rsem-index/1.3.0-gencode44",
-    "reference_indexdir": "$HG38_RSEM_INDEX_ROOT/hg38_random_rsem"
+    "31": {
+      "reference_modules": "rsem/1.3.3 hg38-rsem-index/1.3.0",
+      "reference_indexdir": "$HG38_RSEM_INDEX_ROOT/hg38_random_rsem"
+    },
+    "44": {
+      "reference_modules": "rsem/1.3.3 hg38-rsem-index/1.3.0-gencode44",
+      "reference_indexdir": "$HG38_RSEM_INDEX_ROOT/hg38_random_rsem"
+    }
+  },
+  "hg38_noAlt": {
+    "44": {
+      "reference_modules": "rsem/1.3.3 hg38-noalt-rsem-index/1.3.0-gencode44",
+      "reference_indexdir": "$HG38_RSEM_NOALT_INDEX_ROOT/hg38_noAlt_rsem"
+    }
+  },
+  "grch38": {
+    "44": {
+      "reference_modules": "rsem/1.3.3 grch38-rsem-index/1.3.0-gencode44",
+      "reference_indexdir": "$GRCH38_RSEM_INDEX_ROOT/GCA_000001405.15_GRCh38_rsem"
+    }
   }
 }
 
 # run RSEM
-call runRsem { input: inputFile = inputBam, sampleID = outputFileNamePrefix, modules = resources[reference].reference_modules, rsemIndexDir = resources[reference].reference_indexdir }
+call runRsem { 
+  input: 
+    inputFile = inputBam,
+    sampleID = outputFileNamePrefix,
+    modules = resources[reference][gencode].reference_modules,
+    rsemIndexDir = resources[reference][gencode].reference_indexdir
+}
 
 parameter_meta {
   inputBam: "Input BAM file with aligned RNAseq reads."
   outputFileNamePrefix: "Output prefix, customizable. Default is the input file's basename."
   reference: "Name and version of reference genome"
+  gencode: "Version of gencode used to generate the RSEM indexes"
 }
 
 meta {

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -15,6 +15,7 @@
             },
             "rsem.outputFileNamePrefix": "test_1",
             "rsem.reference": "hg38",
+            "rsem.gencode": "44",
             "rsem.runRsem.jobMemory": null,
             "rsem.runRsem.timeout": null
         },


### PR DESCRIPTION
- additional genomic resources, hg38_noAlt and grch38
- added gencode parameter to support multiple versions of rsem indexes